### PR TITLE
chore(compiler): eliminate warnings

### DIFF
--- a/compiler/src/builder.rs
+++ b/compiler/src/builder.rs
@@ -1,5 +1,4 @@
-use std::io;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 use crate::errors::CompilerError;

--- a/compiler/src/helpers.rs
+++ b/compiler/src/helpers.rs
@@ -5,13 +5,9 @@ use std::{
 };
 
 use file_system::errors::FileSystemError;
-use validator::ast::ExternalFunctionDef;
 
 use crate::builder::get_zig_path;
 
-pub fn extract_external_libraries(externalfns: &Vec<ExternalFunctionDef>) {
-    for exfn in externalfns {}
-}
 pub fn bin_create_dir() -> Result<PathBuf, FileSystemError> {
     let global;
     if let Some(path) = env::current_dir()?.to_str() {

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,20 +1,10 @@
 // mod cleaner;
-use file_system::errors::FileSystemError;
 use parser::parser;
-use validator::ast::ExternalFunctionDef;
 mod helpers;
-use crate::{
-    builder::{build, get_zig_path},
-    errors::CompilerError,
-    helpers::bin_create_dir,
-};
-use std::{
-    env, fs,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use crate::{builder::build, errors::CompilerError, helpers::bin_create_dir};
 mod builder;
 mod errors;
+#[cfg(test)]
 mod tests;
 
 pub fn compiler(path: &str) -> Result<(), CompilerError> {
@@ -23,7 +13,7 @@ pub fn compiler(path: &str) -> Result<(), CompilerError> {
     let parsed_program = parser(sdk)?;
 
     let validator = validator::Validator::default();
-    let (context, program) = validator.validate(parsed_program)?;
+    let (_, program) = validator.validate(parsed_program)?;
 
     let output_zig = bin_create_dir()?;
 

--- a/compiler/src/tests/compiler_test.rs
+++ b/compiler/src/tests/compiler_test.rs
@@ -1,26 +1,16 @@
-use core::panic;
-
-use crate::{bin_create_dir, builder::build, errors::CompilerError, parser};
+use crate::{errors::CompilerError, parser};
 use transpiler::TranspileContext;
 
 #[test]
 fn compiler_variable_test() -> Result<(), CompilerError> {
-    const PATH: &str = "../examples/float.az";
-    let sdk = file_system::read_file(PATH)?;
-
-    let parsed_program = parser(sdk)?;
+    let parsed_program = parser("sabit kəsr a = 5.1\na".to_string())?;
 
     let validator = validator::Validator::default();
-    let (context, program) = validator.validate(parsed_program)?;
+    let (_, program) = validator.validate(parsed_program)?;
 
-    let output_zig = bin_create_dir()?;
-
-    let mut ctx = transpiler::TranspileContext::default();
-
+    let mut ctx = TranspileContext::default();
     let code = ctx.transpile(program);
-    file_system::write_file(&output_zig.join("./src/main.zig"), code)?;
-
-    build(output_zig)?;
+    assert!(code.contains("const a: f64 = 5.1;"));
 
     Ok(())
 }
@@ -32,11 +22,7 @@ fn compiler_binary_op_test() {
     let parsed_program = parser(sdk.unwrap());
     assert!(parsed_program.is_ok());
 
-    let mut program = parsed_program.unwrap();
-
-    let mut validator = validator::Validator::default();
-
-    let varr = validator.validate(program);
+    let _ = parsed_program.unwrap();
     //
     // let mut ctx = TranspileContext::default();
     // assert_eq!(
@@ -54,7 +40,7 @@ fn compiler_float_test() {
     let parsed_program = parser(sdk.unwrap());
     assert!(parsed_program.is_ok());
 
-    let mut program = parsed_program.unwrap();
+    let _ = parsed_program.unwrap();
 
     // let mut validator = validator::Validator::new();
     //
@@ -76,7 +62,7 @@ fn compiler_print_string_interpolation_test() {
     let parsed_program = parser(sdk.unwrap());
     assert!(parsed_program.is_ok());
 
-    let mut program = parsed_program.unwrap();
+    let _ = parsed_program.unwrap();
 }
 #[test]
 fn compiler_condition_test() {
@@ -86,7 +72,7 @@ fn compiler_condition_test() {
     let parsed_program = parser(sdk.unwrap());
     assert!(parsed_program.is_ok());
 
-    let mut program = parsed_program.unwrap();
+    let _ = parsed_program.unwrap();
 }
 #[test]
 fn compiler_function_test() {
@@ -96,7 +82,7 @@ fn compiler_function_test() {
     let parsed_program = parser(sdk.unwrap());
     assert!(parsed_program.is_ok());
 
-    let mut program = parsed_program.unwrap();
+    let _ = parsed_program.unwrap();
 }
 // #[test]
 // pub fn compiler_array() {


### PR DESCRIPTION
## Summary

- remove unused compiler imports and dead helper code
- compile compiler test modules only during test builds
- clean unused test bindings and keep the variable test self-contained
- leave the compiler crate warning-free without suppressing diagnostics

## Testing

- `cargo +1.96.0 check --package compiler --all-targets --locked`
- `cargo +1.96.0 clippy --package compiler --all-targets --no-deps --locked -- -D warnings`
- `cargo +1.96.0 test --package compiler --locked`
- parser, validator, transpiler, and compiler CI package tests

The self-contained variable-test change also appears in #30 so this branch remains independently testable before that PR merges.